### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Go workspace file
+go.work
+
+# Keys and certificates
+*.pem
+
+.github
+credentials
+.dockerignore
+.gitignore
+Dockerfile
+compose.yaml
+README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ on:
   release:
     types: [created]
 permissions:
-    contents: write
-    packages: write
+  contents: write
+  packages: write
 jobs:
   releases-matrix:
     name: Release ja3proxy binary
@@ -13,13 +13,28 @@ jobs:
       matrix:
         # build and publish in parallel: linux/amd64, linux/arm64,
         # windows/amd64, windows/arm64, darwin/amd64, darwin/arm64
-        goos: [ linux, windows, darwin ]
-        goarch: [ amd64, arm64 ]
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v3
-      - uses: wangyoucao577/go-release-action@v1.29
+      - uses: wangyoucao577/go-release-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           binary_name: "ja3proxy"
+  docker-image:
+    name: Build and push Docker image to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and Push Container to ghcr.io
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          image: ja3proxy
+          registry: ghcr.io
+          multiplatform: true
+          platform: linux/amd64,linux/arm64,linux/arm/v7
+          addLatest: true
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 go.work
 
 *.pem
+credentials

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.20 as builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o /app/ja3proxy
+
+FROM gcr.io/distroless/cc-debian12
+
+COPY --from=builder /app/ja3proxy /app/ja3proxy
+ENTRYPOINT ["/app/ja3proxy"]

--- a/README.md
+++ b/README.md
@@ -4,13 +4,39 @@ Customizing TLS (JA3) Fingerprints through HTTP Proxy
 
 ## Usage
 
+### Building from source
+
 ```bash
 git clone https://github.com/lylemi/ja3proxy
 cd ja3proxy
 make
 ./ja3proxy -port 8080 -client 360Browser -version 7.5
+
 curl -v -k --proxy http://localhost:8080 https://www.example.com
 ```
+
+### Using docker CLI
+
+```bash
+docker run \
+      -v ./credentials:/app/credentials \
+      -p 8080:8080 \
+      ghcr.io/lylemi/ja3proxy:latest \
+      -cert /app/credentials/cert.pem \
+      -key /app/credentials/key.pem \
+      -client 360Browser \
+      -version 7.5
+```
+
+### Using docker compose
+
+See [`compose.yaml`](https://github.com/LyleMi/ja3proxy/blob/master/compose.yaml)
+
+```bash
+docker compose up -d
+```
+
+### CLI usage
 
 ```bash
 Usage of ja3proxy:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,20 @@
+services:
+  ja3proxy:
+    image: ghcr.io/lylemi/ja3proxy:latest
+    build: .
+    entrypoint:
+      [
+        "/app/ja3proxy",
+        "-cert",
+        "/app/credentials/cert.pem",
+        "-key",
+        "/app/credentials/key.pem",
+        "-client",
+        "360Browser",
+        "-version",
+        "7.5"
+      ]
+    ports:
+      - 8080:8080
+    volumes:
+      - ./credentials:/app/credentials


### PR DESCRIPTION
Adds docker images for ja3proxy

- Images are automatically built and pushed to GitHub Container Registry on each new release (through workflow)
- Latest image is automatically tagged with `latest`
- Supported architectures: amd64, arm64, armv7 (option to add more)
- Adjusted documentation to reflect Docker usage
- Also fixed binary releases by updating the version of the action used