### PR TITLE
Use Config struct instead of passing values to generateCertificate

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func generateCertificate(certPath, keyPath string) error {
+func generateCertificate() error {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return err
@@ -35,14 +35,14 @@ func generateCertificate(certPath, keyPath string) error {
 		return err
 	}
 
-	certOut, err := os.Create(certPath)
+	certOut, err := os.Create(Config.Cert)
 	if err != nil {
 		return err
 	}
 	defer certOut.Close()
 	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 
-	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	keyOut, err := os.OpenFile(Config.Key, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -169,7 +169,7 @@ func main() {
 		}
 
 		log.Println("cert and key do not exist, generating")
-		generateCertificate(Config.Cert, Config.Key)
+		generateCertificate()
 	}
 
 	server := &http.Server{


### PR DESCRIPTION
Minor largely cosmetic change to my previous PR (#6) since I didn't know package-level variables are a feature in Go. Last PR for today.