### PR TITLE
Load certificate at startup

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -3,9 +3,11 @@ package main
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"log"
 	"math/big"
 	"os"
 	"time"
@@ -50,3 +52,16 @@ func generateCertificate() error {
 	pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
 	return nil
 }
+
+func loadCertificate() {
+	cert, err := tls.LoadX509KeyPair(Config.Cert, Config.Key)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		LoadedCert = cert
+	}
+}
+
+var (
+	LoadedCert tls.Certificate
+)

--- a/proxy.go
+++ b/proxy.go
@@ -22,7 +22,7 @@ func fileExists(filename string) bool {
 
 func customTLSWrap(conn net.Conn, sni string) (*utls.UConn, error) {
 	clientHelloID := utls.ClientHelloID{
-		Config.TLSClient, Config.TLSVersion, nil, nil,
+		Client: Config.TLSClient, Version: Config.TLSVersion, Seed: nil, Weights: nil,
 	}
 
 	uTLSConn := utls.UClient(
@@ -86,14 +86,9 @@ func connect(sni string, destConn net.Conn, clientConn net.Conn) {
 		return
 	}
 
-	cert, err := tls.LoadX509KeyPair(Config.Cert, Config.Key)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	config := &tls.Config{
 		InsecureSkipVerify: true,
-		Certificates:       []tls.Certificate{cert},
+		Certificates:       []tls.Certificate{LoadedCert},
 	}
 
 	state := destTLSConn.ConnectionState()
@@ -171,6 +166,8 @@ func main() {
 		log.Println("cert and key do not exist, generating")
 		generateCertificate()
 	}
+
+	loadCertificate()
 
 	server := &http.Server{
 		Addr: Config.Addr + ":" + Config.Port,


### PR DESCRIPTION
Fixes #7

I'm not familiar with golang, thus I'd appreciate it if this PR was reviewed before being merged.

Certificates are loaded after certificate generation and before the server starts. Incorrect certificate and private key files are thus detected before the first connection and files aren't reloaded on every connection.