### PR TITLE
fix: stop goroutine leaks by ensuring both goroutines exit properly

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -24,7 +24,7 @@ func (writer DebugWriter) Write(data []byte) (n int, err error) {
 }
 
 func debugJunction(destConn net.Conn, clientConn net.Conn) {
-	chDone := make(chan bool)
+	chDone := make(chan bool, 2)
 
 	go func() {
 		defer func() {
@@ -60,5 +60,7 @@ func debugJunction(destConn net.Conn, clientConn net.Conn) {
 		}
 	}()
 
+	// wait for both copy ops to complete
+	<-chDone
 	<-chDone
 }

--- a/proxy.go
+++ b/proxy.go
@@ -120,7 +120,7 @@ func connect(sni string, destConn net.Conn, clientConn net.Conn) {
 }
 
 func junction(destConn net.Conn, clientConn net.Conn) {
-	chDone := make(chan bool)
+	chDone := make(chan bool, 2)
 
 	go func() {
 		_, err := io.Copy(destConn, clientConn)
@@ -138,6 +138,8 @@ func junction(destConn net.Conn, clientConn net.Conn) {
 		chDone <- true
 	}()
 
+	// wait for both copy ops to complete
+	<-chDone
 	<-chDone
 }
 


### PR DESCRIPTION
- Use buffered channels to prevent goroutines from hanging
- Improve stability and perf under high traffic